### PR TITLE
Add tooltip on InstalledVersion column with location of this vulnerability

### DIFF
--- a/src/frontend-app/src/components/trivy-report/Vulnerabilities.tsx
+++ b/src/frontend-app/src/components/trivy-report/Vulnerabilities.tsx
@@ -167,6 +167,9 @@ const Vulnerabilities: React.FC<VulnerabilitiesProps> = ({ result }) => {
       ...getColumnSearchProps('InstalledVersion'),
       sorter: (a: NormalizedResultForDataTable, b: NormalizedResultForDataTable) => localeCompare(a.InstalledVersion, b.InstalledVersion),
       sortDirections: ['descend', 'ascend'],
+      render:(text, record)=>(
+          <span title={'Location: '+record.PkgPath}>{text} </span>
+      ),
     },
     {
       title: 'Fixed Version',

--- a/src/frontend-app/src/components/trivy-report/Vulnerabilities.tsx
+++ b/src/frontend-app/src/components/trivy-report/Vulnerabilities.tsx
@@ -167,8 +167,8 @@ const Vulnerabilities: React.FC<VulnerabilitiesProps> = ({ result }) => {
       ...getColumnSearchProps('InstalledVersion'),
       sorter: (a: NormalizedResultForDataTable, b: NormalizedResultForDataTable) => localeCompare(a.InstalledVersion, b.InstalledVersion),
       sortDirections: ['descend', 'ascend'],
-      render:(text, record)=>(
-          <span title={'Location: '+record.PkgPath}>{text} </span>
+      render:(text, record)=> (
+          <span title={record.PkgPath ? 'Path: ' + record.PkgPath : ''}>{text} </span>
       ),
     },
     {

--- a/src/frontend-app/src/types/external/defaultResult.ts
+++ b/src/frontend-app/src/types/external/defaultResult.ts
@@ -73,6 +73,7 @@ export type Vulnerability = {
   VulnerabilityID: string;
   Severity: string;
   InstalledVersion: string;
+  PkgPath: string;
   FixedVersion: string;
   Title: string;
   SeveritySource: string;

--- a/src/frontend-app/src/types/external/defaultResult.ts
+++ b/src/frontend-app/src/types/external/defaultResult.ts
@@ -69,10 +69,10 @@ export type MisconfSummary = {
 };
 
 export type Vulnerability = {
-  PkgName: string;
   VulnerabilityID: string;
   Severity: string;
   InstalledVersion: string;
+  PkgName: string;
   PkgPath: string;
   FixedVersion: string;
   Title: string;

--- a/src/frontend-app/src/types/index.ts
+++ b/src/frontend-app/src/types/index.ts
@@ -9,6 +9,7 @@ export class NormalizedResultForDataTable {
   Severity?: string;
   InstalledVersion?: string;
   FixedVersion?: string;
+  PkgPath?: string;
   Title?: string;
   Type: string = "";
   Message?: string;

--- a/src/frontend-app/src/utils/index.tsx
+++ b/src/frontend-app/src/utils/index.tsx
@@ -180,6 +180,7 @@ function mapVulnerabilityResults(results: CommonResult[]): NormalizedResultForDa
           NVD_V3Score: NVD_V3Score,
           Severity: vulnerability.Severity,
           InstalledVersion: vulnerability.InstalledVersion,
+          PkgPath: vulnerability.PkgPath,
           FixedVersion: vulnerability.FixedVersion,
           Title: vulnerability.Title,
           References: vulnerability.References,

--- a/src/js/report.js
+++ b/src/js/report.js
@@ -135,6 +135,7 @@ function mapVulnerabilityResults(results) {
                         "Vulnerability": vulnerability.VulnerabilityID,
                         "Severity": vulnerability.Severity,
                         "InstalledVersion": vulnerability.InstalledVersion,
+                        "PkgPath": vulnerability.PkgPath,
                         "FixedVersion": vulnerability.FixedVersion,
                         "Title": vulnerability.Title
                     }


### PR DESCRIPTION
Sometimes it is hard to find location of vulnerability. Especially when classes/jars are assembled in another jars


![tooltip_example](https://github.com/user-attachments/assets/8d1ec1f6-1979-4e1e-975f-b120ea4ec410)
