### PR TITLE
Actually use EPSS score instead of percentile

### DIFF
--- a/src/frontend-app/src/utils/index.tsx
+++ b/src/frontend-app/src/utils/index.tsx
@@ -44,7 +44,7 @@ function enrichWithEPSSCores(vulnerabilities: NormalizedResultForDataTable[], ep
   vulnerabilities.forEach(vulnerability => {
     let EPSS_Score = epssData.filter(epssPerVulnerability =>  epssPerVulnerability.cve === vulnerability.ID)[0];
     if (EPSS_Score) {
-      vulnerability.EPSS_Score = parseFloat((EPSS_Score.percentile * 100).toFixed(2));
+      vulnerability.EPSS_Score = parseFloat((EPSS_Score.epss * 100).toFixed(2));
     }
   });
 


### PR DESCRIPTION
scan2html currently displays the percentile of each CVEs EPSS score in the column named "EPSS Score %" - which isn't necessarily bad, but it isn't the actual score itself.

https://github.com/fatihtokus/scan2html/issues/174