### PR TITLE
Adding dark theme support  #104

### DIFF
--- a/src/frontend-app/src/App.css
+++ b/src/frontend-app/src/App.css
@@ -2,6 +2,97 @@
   margin: 10px;
 }
 
+/* Theme support for main layout */
+#content {
+  background-color: inherit;
+}
+
+/* Dark theme support - match sidebar dark color */
+html[data-theme="dark"] #content {
+  background-color: #001529;
+  color: #ffffff;
+}
+
+/* Light theme support - match sidebar light color */
+html[data-theme="light"] #content {
+  background-color: #fafafa;
+  color: #000000;
+}
+
+html[data-theme="dark"] #menu {
+  background-color: #001529;
+}
+
+html[data-theme="light"] #menu {
+  background-color: #fafafa;
+}
+
+/* Make the main container also inherit the background */
+.ant-layout {
+  background-color: inherit !important;
+}
+
+/* Remove harsh borders and shadows in light mode */
+html[data-theme="light"] .ant-table-wrapper,
+html[data-theme="light"] .ant-table,
+html[data-theme="light"] .ant-card,
+html[data-theme="light"] .ant-btn,
+html[data-theme="light"] .ant-input,
+html[data-theme="light"] .ant-select-selector {
+  border: 1px solid rgba(0, 0, 0, 0.06) !important;
+  box-shadow: none !important;
+}
+
+/* Remove harsh borders and shadows in dark mode */
+html[data-theme="dark"] .ant-table-wrapper,
+html[data-theme="dark"] .ant-table,
+html[data-theme="dark"] .ant-card,
+html[data-theme="dark"] .ant-btn,
+html[data-theme="dark"] .ant-input,
+html[data-theme="dark"] .ant-select-selector {
+  border: 1px solid rgba(255, 255, 255, 0.08) !important;
+  box-shadow: none !important;
+}
+
+/* Smooth table styling */
+.ant-table-thead > tr > th {
+  border-bottom: none !important;
+}
+
+.ant-table-tbody > tr > td {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.03) !important;
+}
+
+html[data-theme="dark"] .ant-table-tbody > tr > td {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05) !important;
+}
+
+/* Softer hover effects */
+.ant-table-tbody > tr:hover > td {
+  background-color: rgba(0, 0, 0, 0.02) !important;
+}
+
+html[data-theme="dark"] .ant-table-tbody > tr:hover > td {
+  background-color: rgba(255, 255, 255, 0.03) !important;
+}
+
+/* Remove card shadows for seamless look */
+.ant-card {
+  box-shadow: none !important;
+  border-radius: 8px !important;
+}
+
+/* Button styling */
+.ant-btn {
+  border-radius: 6px !important;
+}
+
+/* Tag styling for better integration */
+.ant-tag {
+  border: none !important;
+  border-radius: 4px !important;
+}
+
 /* #root {
   max-width: 1280px;
   margin: 0 auto;

--- a/src/frontend-app/src/App.css
+++ b/src/frontend-app/src/App.css
@@ -28,69 +28,71 @@ html[data-theme="light"] #menu {
 }
 
 /* Make the main container also inherit the background */
-.ant-layout {
-  background-color: inherit !important;
+html[data-theme] .ant-layout {
+  background-color: inherit;
 }
 
 /* Remove harsh borders and shadows in light mode */
+html[data-theme="light"] .ant-table-wrapper .ant-table,
 html[data-theme="light"] .ant-table-wrapper,
 html[data-theme="light"] .ant-table,
-html[data-theme="light"] .ant-card,
-html[data-theme="light"] .ant-btn,
-html[data-theme="light"] .ant-input,
-html[data-theme="light"] .ant-select-selector {
-  border: 1px solid rgba(0, 0, 0, 0.06) !important;
-  box-shadow: none !important;
+html[data-theme="light"] .ant-card.ant-card,
+html[data-theme="light"] .ant-btn.ant-btn,
+html[data-theme="light"] .ant-input.ant-input,
+html[data-theme="light"] .ant-select .ant-select-selector {
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  box-shadow: none;
 }
 
 /* Remove harsh borders and shadows in dark mode */
+html[data-theme="dark"] .ant-table-wrapper .ant-table,
 html[data-theme="dark"] .ant-table-wrapper,
 html[data-theme="dark"] .ant-table,
-html[data-theme="dark"] .ant-card,
-html[data-theme="dark"] .ant-btn,
-html[data-theme="dark"] .ant-input,
-html[data-theme="dark"] .ant-select-selector {
-  border: 1px solid rgba(255, 255, 255, 0.08) !important;
-  box-shadow: none !important;
+html[data-theme="dark"] .ant-card.ant-card,
+html[data-theme="dark"] .ant-btn.ant-btn,
+html[data-theme="dark"] .ant-input.ant-input,
+html[data-theme="dark"] .ant-select .ant-select-selector {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: none;
 }
 
 /* Smooth table styling */
-.ant-table-thead > tr > th {
-  border-bottom: none !important;
+html[data-theme] .ant-table .ant-table-thead > tr > th {
+  border-bottom: none;
 }
 
-.ant-table-tbody > tr > td {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.03) !important;
+html[data-theme] .ant-table .ant-table-tbody > tr > td {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.03);
 }
 
-html[data-theme="dark"] .ant-table-tbody > tr > td {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05) !important;
+html[data-theme="dark"] .ant-table .ant-table-tbody > tr > td {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 /* Softer hover effects */
-.ant-table-tbody > tr:hover > td {
-  background-color: rgba(0, 0, 0, 0.02) !important;
+html[data-theme] .ant-table .ant-table-tbody > tr:hover > td {
+  background-color: rgba(0, 0, 0, 0.02);
 }
 
-html[data-theme="dark"] .ant-table-tbody > tr:hover > td {
-  background-color: rgba(255, 255, 255, 0.03) !important;
+html[data-theme="dark"] .ant-table .ant-table-tbody > tr:hover > td {
+  background-color: rgba(255, 255, 255, 0.03);
 }
 
 /* Remove card shadows for seamless look */
-.ant-card {
-  box-shadow: none !important;
-  border-radius: 8px !important;
+html[data-theme] .ant-card.ant-card {
+  box-shadow: none;
+  border-radius: 8px;
 }
 
 /* Button styling */
-.ant-btn {
-  border-radius: 6px !important;
+html[data-theme] .ant-btn.ant-btn {
+  border-radius: 6px;
 }
 
 /* Tag styling for better integration */
-.ant-tag {
-  border: none !important;
-  border-radius: 4px !important;
+html[data-theme] .ant-tag.ant-tag {
+  border: none;
+  border-radius: 4px;
 }
 
 /* #root {

--- a/src/frontend-app/src/App.tsx
+++ b/src/frontend-app/src/App.tsx
@@ -24,6 +24,37 @@ type MenuItem = {
   label: string;
 };
 
+const getThemeConfig = (isDark: boolean) => ({
+  algorithm: isDark ? antdTheme.darkAlgorithm : antdTheme.defaultAlgorithm,
+  token: {
+    borderRadius: 8,
+    colorBorder: isDark ? "rgba(255, 255, 255, 0.08)" : "rgba(0, 0, 0, 0.06)",
+    boxShadow: "none",
+    boxShadowSecondary: "none",
+    controlOutline: "none",
+  },
+  components: {
+    Table: {
+      borderColor: isDark ? "rgba(255, 255, 255, 0.05)" : "rgba(0, 0, 0, 0.03)",
+      headerBg: "transparent",
+      bodySortBg: "transparent",
+      rowHoverBg: isDark ? "rgba(255, 255, 255, 0.03)" : "rgba(0, 0, 0, 0.02)",
+    },
+    Card: {
+      boxShadow: "none",
+      boxShadowTertiary: "none",
+    },
+    Button: {
+      boxShadow: "none",
+      primaryShadow: "none",
+    },
+    Input: {
+      boxShadow: "none",
+      activeShadow: "none",
+    },
+  },
+});
+
 function App() {
   const [vulnerabilities, setVulnerabilities] = useState<NormalizedResultForDataTable[]>([]);
   const [secrets, setSecrets] = useState<NormalizedResultForDataTable[]>([]);
@@ -232,42 +263,12 @@ function App() {
 
   return (
     <ConfigProvider
-      theme={{
-        algorithm: theme === "dark" ? antdTheme.darkAlgorithm : antdTheme.defaultAlgorithm,
-        token: {
-          borderRadius: 8,
-          colorBorder: theme === "dark" ? "rgba(255, 255, 255, 0.08)" : "rgba(0, 0, 0, 0.06)",
-          boxShadow: "none",
-          boxShadowSecondary: "none",
-          controlOutline: "none",
-        },
-        components: {
-          Table: {
-            borderColor: theme === "dark" ? "rgba(255, 255, 255, 0.05)" : "rgba(0, 0, 0, 0.03)",
-            headerBg: "transparent",
-            bodySortBg: "transparent",
-            rowHoverBg: theme === "dark" ? "rgba(255, 255, 255, 0.03)" : "rgba(0, 0, 0, 0.02)",
-          },
-          Card: {
-            boxShadow: "none",
-            boxShadowTertiary: "none",
-          },
-          Button: {
-            boxShadow: "none",
-            primaryShadow: "none",
-          },
-          Input: {
-            boxShadow: "none",
-            activeShadow: "none",
-          },
-        },
-      }}
+      theme={getThemeConfig(theme === "dark")}
     >
       <div
         style={{
           display: "flex",
           minHeight: "100vh",
-          backgroundColor: theme === "dark" ? "#001529" : "#fafafa",
         }}
       >
         <div id="menu">
@@ -282,7 +283,6 @@ function App() {
           style={{
             flexGrow: 1,
             marginLeft: 20,
-            backgroundColor: theme === "dark" ? "#001529" : "#fafafa",
           }}
         >
           <TableTitle title={reportTitle} />

--- a/src/frontend-app/src/App.tsx
+++ b/src/frontend-app/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Button, notification, Menu, Switch, MenuTheme } from "antd";
+import { Button, notification, Menu, Switch, MenuTheme, ConfigProvider, theme as antdTheme } from "antd";
 import Papa, { ParseResult } from "papaparse";
 import TrivyReport from "./components/trivy-report/TrivyReport";
 import TableTitle from "./components/shared/TableTitle";
@@ -48,6 +48,11 @@ function App() {
   const onThemeChanged = (value: boolean) => {
     setTheme(value ? 'dark' : 'light');
   };
+
+  // Update document attribute when theme changes
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+  }, [theme]);
 
   const onToggleCollapsed = () => {
     setCollapsed(!collapsed);
@@ -226,45 +231,78 @@ function App() {
   };
 
   return (
-    <div style={{ display: "flex", minHeight: "100vh" }}>
-      <div id="menu">
-        <Switch
-          checked={theme === 'dark'}
-          onChange={onThemeChanged}
-          checkedChildren="Dark"
-          unCheckedChildren="Light"
-        />
-        <Button type="primary" onClick={onToggleCollapsed} style={{ margin: 16 }}>
-          {collapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
-        </Button>
-        <Menu
-          defaultSelectedKeys={["vulnerabilities"]}
-          selectedKeys={[selectedMenu]}
-          mode="inline"
-          theme={theme}
-          inlineCollapsed={collapsed}
-          items={menuItems}
-          onClick={onMenuSelected}
-        />
+    <ConfigProvider
+      theme={{
+        algorithm: theme === "dark" ? antdTheme.darkAlgorithm : antdTheme.defaultAlgorithm,
+        token: {
+          borderRadius: 8,
+          colorBorder: theme === "dark" ? "rgba(255, 255, 255, 0.08)" : "rgba(0, 0, 0, 0.06)",
+          boxShadow: "none",
+          boxShadowSecondary: "none",
+          controlOutline: "none",
+        },
+        components: {
+          Table: {
+            borderColor: theme === "dark" ? "rgba(255, 255, 255, 0.05)" : "rgba(0, 0, 0, 0.03)",
+            headerBg: "transparent",
+            bodySortBg: "transparent",
+            rowHoverBg: theme === "dark" ? "rgba(255, 255, 255, 0.03)" : "rgba(0, 0, 0, 0.02)",
+          },
+          Card: {
+            boxShadow: "none",
+            boxShadowTertiary: "none",
+          },
+          Button: {
+            boxShadow: "none",
+            primaryShadow: "none",
+          },
+          Input: {
+            boxShadow: "none",
+            activeShadow: "none",
+          },
+        },
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          minHeight: "100vh",
+          backgroundColor: theme === "dark" ? "#001529" : "#fafafa",
+        }}
+      >
+        <div id="menu">
+          <Switch checked={theme === "dark"} onChange={onThemeChanged} checkedChildren="Dark" unCheckedChildren="Light" />
+          <Button type="primary" onClick={onToggleCollapsed} style={{ margin: 16 }}>
+            {collapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
+          </Button>
+          <Menu defaultSelectedKeys={["vulnerabilities"]} selectedKeys={[selectedMenu]} mode="inline" theme={theme} inlineCollapsed={collapsed} items={menuItems} onClick={onMenuSelected} />
+        </div>
+        <div
+          id="content"
+          style={{
+            flexGrow: 1,
+            marginLeft: 20,
+            backgroundColor: theme === "dark" ? "#001529" : "#fafafa",
+          }}
+        >
+          <TableTitle title={reportTitle} />
+          <TrivyReport
+            vulnerabilities={vulnerabilities}
+            secrets={secrets}
+            licenses={licenses}
+            misconfigurations={misconfigurations}
+            misconfigurationSummary={misconfigurationSummary}
+            k8sClusterSummaryInfraAssessment={k8sClusterSummaryInfraAssessment}
+            k8sClusterSummaryRBACAssessment={k8sClusterSummaryRBACAssessment}
+            selectedMenu={selectedMenu}
+            supplyChainSBOM={supplyChainSBOM}
+            onReportUpload={onReportUpload}
+            loadedReportFiles={loadedReportFiles}
+            manuallyLoadedReportFile={manuallyLoadedReportFile}
+          />
+        </div>
       </div>
-      <div id="content" style={{ flexGrow: 1, marginLeft: 20 }}>
-        <TableTitle title={reportTitle}/>  
-        <TrivyReport
-          vulnerabilities={vulnerabilities}
-          secrets={secrets}
-          licenses={licenses}
-          misconfigurations={misconfigurations}
-          misconfigurationSummary={misconfigurationSummary}
-          k8sClusterSummaryInfraAssessment={k8sClusterSummaryInfraAssessment}
-          k8sClusterSummaryRBACAssessment={k8sClusterSummaryRBACAssessment}
-          selectedMenu={selectedMenu}
-          supplyChainSBOM={supplyChainSBOM}
-          onReportUpload={onReportUpload}
-          loadedReportFiles={loadedReportFiles}
-          manuallyLoadedReportFile={manuallyLoadedReportFile}
-        />
-      </div>
-    </div>
+    </ConfigProvider>
   );
 }
 

--- a/src/frontend-app/src/index.css
+++ b/src/frontend-app/src/index.css
@@ -1,40 +1,57 @@
-/* :root {
+/* Root styles for theme support */
+:root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Default light theme - using sidebar colors */
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  background-color: #fafafa;
+  color: #000000;
+}
+
+/* Dark theme - using sidebar dark colors with smooth transitions */
+html[data-theme="dark"],
+html[data-theme="dark"] body {
+  background-color: #001529;
+  color: #ffffff;
+}
+
+#root {
+  min-height: 100vh;
+  background-color: inherit;
+}
+
+/* Smooth link styling */
 a {
   font-weight: 500;
   color: #646cff;
   text-decoration: inherit;
 }
+
 a:hover {
   color: #535bf2;
 }
 
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+/* Dark theme link colors */
+html[data-theme="dark"] a {
+  color: #69c0ff;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+html[data-theme="dark"] a:hover {
+  color: #91d5ff;
 }
 
+/* Button styling */
 button {
   border-radius: 8px;
   border: 1px solid transparent;
@@ -65,4 +82,4 @@ button:focus-visible {
   button {
     background-color: #f9f9f9;
   }
-} */
+}


### PR DESCRIPTION
Hey,
I first wanted to say this is my first ever contribution to open source, so if there is anything I did wrong, please let me know.

I am using scan2html a lot, and I saw that the dark theme is working on the sidebar only and not for the whole report.
I added support to dark theme.

I notice that the css file had configurations before and was commented out, I don't know if it is on purpose or not, let me know if I need to move it to another place.

I tested my changes with a scan with an app called yacht
` trivy image --format json selfhostedpro/yacht:latest -o test.json` 
and used it's output to test the dark mode.


<img width="1901" height="892" alt="image" src="https://github.com/user-attachments/assets/ae2cac79-70ae-42a3-b0e9-dd3df871dc91" />
