### PR TITLE
fix: update vite to 5.5.0+ to patch Rollup path traversal vulnerability

### DIFF
--- a/src/frontend-app/package.json
+++ b/src/frontend-app/package.json
@@ -31,7 +31,7 @@
     "prettier": "3.2.5",
     "raw-loader": "^4.0.2",
     "typescript": "^5.2.2",
-    "vite": "^5.4.14",
+    "vite": "^5.5.0",
     "vite-plugin-css-injected-by-js": "^3.4.0"
   }
 }


### PR DESCRIPTION
- Upgraded vite from 5.4.14 to 5.5.0+ which includes patched Rollup version
- Fixes CVE: Arbitrary File Write via Path Traversal in Rollup
- Rollup now properly sanitizes filenames to prevent path traversal sequences (../)
- This prevents attackers from writing files outside the intended output directory

Resolves: https://github.com/fatihtokus/scan2html/security/dependabot/37